### PR TITLE
Hide gradle build properties contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Comment prefixes:
 - 🔵 Upgraded android targetSdk to 36
 - 🟢 Added edge-to-edge UI compliant with android targetSdk 36
 - 🟠 Updated top bar default state to collapsed
+- 🟡 Gradle build properties contents are now sourced externally
 #### 2025-07-28
 - 🟠 Updated hardcoded content
 - 🟢 Changelog format updated

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import java.io.FileInputStream
 import java.util.Properties
 
 plugins {
@@ -36,8 +35,8 @@ android {
         applicationId = "pt.rvcoding.cvnotes"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 3
-        versionName = "1.1.2"
+        versionCode = 4
+        versionName = "1.1.2-SNAPSHOT"
 
         testInstrumentationRunner = "pt.rvcoding.cvnotes.HiltTestRunner"
         vectorDrawables.useSupportLibrary = true
@@ -48,33 +47,18 @@ android {
 
     signingConfigs {
         getByName("debug") {
-            storeFile = file("../debug.jks")
-            storePassword = "my4PP!D3bUg"
-            keyAlias = "debug"
-            keyPassword = "my4PP!D3bUg"
+            val debugPath = "../rvcoding/debug.properties"
+            storeFile = file("../../rvcoding/debug.jks")
+            storePassword = project.loadLocalProperty(debugPath, "storePassword")
+            keyAlias = project.loadLocalProperty(debugPath, "keyAlias")
+            keyPassword = project.loadLocalProperty(debugPath, "keyPassword")
         }
-
-        val keyPropertiesFile = file("../../rvcoding/release.properties")
-        if (keyPropertiesFile.canRead()) {
-            println("Release build set with release keystore")
-
-            val properties = Properties()
-            properties.load(FileInputStream(keyPropertiesFile))
-            create("release") {
-                storeFile = file("../../rvcoding/release.jks")
-                storePassword = properties["storePassword"].toString()
-                keyAlias = properties["keyAlias"].toString()
-                keyPassword = properties["keyPassword"].toString()
-            }
-        } else {
-            println("Release build set with debug keystore")
-
-            create("release") {
-                storeFile = file("../debug.jks")
-                storePassword = "my4PP!D3bUg"
-                keyAlias = "debug"
-                keyPassword = "my4PP!D3bUg"
-            }
+        create("release") {
+            val releasePath = "../rvcoding/release.properties"
+            storeFile = file("../../rvcoding/release.jks")
+            storePassword = project.loadLocalProperty(releasePath, "storePassword")
+            keyAlias = project.loadLocalProperty(releasePath, "keyAlias")
+            keyPassword = project.loadLocalProperty(releasePath, "keyPassword")
         }
 
         buildTypes {
@@ -208,5 +192,20 @@ android {
     apply(plugin = "com.google.firebase.crashlytics")
 }
 
+fun Project.loadLocalProperty(
+    path: String,
+    propertyName: String,
+): String {
+    val localProperties = Properties()
+    val localPropertiesFile = project.rootProject.file(path)
+    return try {
+        localProperties.load(localPropertiesFile.inputStream())
+        val property = localProperties.getProperty(propertyName)
+        property
+    } catch (e: Exception) {
+        println(GradleException("Error loading local property $propertyName: ${e.toString()}"))
+        ""
+    }
+}
 
 


### PR DESCRIPTION
Why:
- Property contents were set explicitly leaking sensible information.

How:
- Grab the contents from an external source of properties files.