### PR TITLE
feat: AppFunctions for CVNotes + docs; changelog

### DIFF
--- a/app/src/main/java/pt/rvcoding/cvnotes/CVNotesApp.kt
+++ b/app/src/main/java/pt/rvcoding/cvnotes/CVNotesApp.kt
@@ -2,23 +2,24 @@ package pt.rvcoding.cvnotes
 
 import android.app.Application
 import androidx.appfunctions.service.AppFunctionConfiguration
-import dagger.hilt.android.HiltAndroidApp
 import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.android.HiltAndroidApp
 import pt.rvcoding.cvnotes.appfunctions.CVNotesAppFunctions
 import pt.rvcoding.cvnotes.di.AppFunctionsEntryPoint
 
 @HiltAndroidApp
 class CVNotesApp : Application(), AppFunctionConfiguration.Provider {
 
-    override fun getAppFunctionConfiguration(): AppFunctionConfiguration {
-        val entryPoint = EntryPointAccessors.fromApplication(
-            this,
-            AppFunctionsEntryPoint::class.java,
-        )
-        return AppFunctionConfiguration(
-            mapOf(
-                CVNotesAppFunctions::class.java to { entryPoint.cvNotesAppFunctions() },
-            ),
-        )
-    }
+    override val appFunctionConfiguration: AppFunctionConfiguration
+        get() {
+            val entryPoint = EntryPointAccessors.fromApplication(
+                this,
+                AppFunctionsEntryPoint::class.java,
+            )
+            return AppFunctionConfiguration.Builder()
+                .addEnclosingClassFactory(CVNotesAppFunctions::class.java) {
+                    entryPoint.cvNotesAppFunctions()
+                }
+                .build()
+        }
 }

--- a/docs/APPFUNCTIONS.md
+++ b/docs/APPFUNCTIONS.md
@@ -254,7 +254,7 @@ Parse **`ExecuteAppFunctionResponse`** according to the alpha API you use (respo
 
 For contributors maintaining the app:
 
-- **`CVNotesApp`**: implements `AppFunctionConfiguration.Provider`, returns `AppFunctionConfiguration` mapping `CVNotesAppFunctions::class.java` to a Hilt-provided instance (`AppFunctionsEntryPoint`).
+- **`CVNotesApp`**: implements `AppFunctionConfiguration.Provider` and exposes `appFunctionConfiguration` via `AppFunctionConfiguration.Builder().addEnclosingClassFactory(...)` (the primary `AppFunctionConfiguration` constructor is library-internal).
 - **KSP**: `appfunctions-compiler` generates schema / inventory consumed by the system.
 - **Manifest**: the `appfunctions-service` artifact merges **`PlatformAppFunctionService`** and related metadata (you normally do not declare this service by hand).
 - **ProGuard**: rules in `app/proguard-rules.pro` keep `CVNotesAppFunctions` and `AppFunction*` models for release.


### PR DESCRIPTION
Why:
Let on-device agents and assistants (per Android AppFunctions) discover and invoke CVNotes actions—navigation, section/note CRUD, and id discovery—while documenting how external callers use AppFunctionManager and what Gemini / system-assistant integration realistically guarantees during the experimental preview.

How:
- Add androidx.appfunctions (implementation + service) and appfunctions-compiler via KSP; version catalog entries.
- Implement CVNotesAppFunctions with @AppFunction APIs, AppFunctionSerializable DTOs, PendingNavigationHolder, and MainActivity OnDestinationChangedListener for deferred navigation inside the Home graph.
- CVNotesApp implements AppFunctionConfiguration.Provider using Hilt AppFunctionsEntryPoint; ProGuard keeps for AppFunctions classes.
- Add docs/APPFUNCTIONS.md (caller examples, agents, Gemini caveats) and CHANGELOG.md entries under 1.2.1-SNAPSHOT / 2026-04-07.

+fix: AppFunctionConfiguration

fix